### PR TITLE
Add 'ENV RUBYOPT -EUTF-8' to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM ruby:2.5
+#  https://blog.sshn.me/posts/invalid-byte-sequence-in-usascii/ 
+ENV RUBYOPT -EUTF-8
 
 RUN mkdir /work && mkdir /data
 


### PR DESCRIPTION
片山さんからの以下の問合せと同じ問題の対応です。XMLにASCIIコード以外が含まれている場合に対応するためです。
https://togovar.slack.com/archives/CTCHES648/p1594177601194700